### PR TITLE
Add Turborepo-inspired performance and workflow features

### DIFF
--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -1,0 +1,90 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import { ConfigManager } from '../lib/config.js';
+import CloudBackend from '../lib/cloud.js';
+
+export function registerHistoryCommand(program: Command): void {
+  program
+    .command('history')
+    .description('List past sync snapshots')
+    .option('-n, --limit <n>', 'number of snapshots to show', '20')
+    .option('--from <machine>', 'filter by machine name or ID')
+    .action(async (options: { limit: string; from?: string }) => {
+      const configManager = new ConfigManager();
+
+      if (!configManager.exists()) {
+        console.error(chalk.red("Error: Run 'configsync init' first."));
+        process.exit(1);
+      }
+
+      const config = configManager.load();
+
+      if (config.sync.backend !== 'cloud') {
+        console.error(chalk.red('History is only available with cloud backend.'));
+        process.exit(1);
+      }
+
+      const apiUrl = config.sync.config.api_url;
+      const apiKey = config.sync.config.api_key;
+
+      if (!apiUrl || !apiKey) {
+        console.error(chalk.red('Cloud backend not configured. Run "configsync login" first.'));
+        process.exit(1);
+      }
+
+      const spinner = ora('Fetching history...').start();
+
+      try {
+        const backend = new CloudBackend(apiUrl, apiKey);
+        const limit = parseInt(options.limit, 10) || 20;
+
+        let machineId: string | undefined;
+        if (options.from) {
+          const machines = await backend.listMachines();
+          const match = machines.find((m: any) =>
+            m.machine_id === options.from ||
+            m.name.toLowerCase().includes(options.from!.toLowerCase())
+          );
+          if (match) machineId = match.machine_id;
+        }
+
+        const snapshots = await backend.getHistory(machineId, limit);
+        spinner.stop();
+
+        if (!snapshots || snapshots.length === 0) {
+          console.log(chalk.dim('No snapshots found.'));
+          return;
+        }
+
+        console.log(chalk.bold(`\nSnapshot history (${snapshots.length}):\n`));
+        console.log(
+          chalk.dim('  ID'.padEnd(8)) +
+          chalk.dim('Timestamp'.padEnd(24)) +
+          chalk.dim('Machine'.padEnd(20)) +
+          chalk.dim('Size'),
+        );
+        console.log(chalk.dim('  ' + '─'.repeat(60)));
+
+        for (const snap of snapshots) {
+          const id = String(snap.id).padEnd(6);
+          const time = (snap.created_at || '').slice(0, 19).padEnd(22);
+          const machine = (snap.machine_name || snap.machine_id || '').slice(0, 18).padEnd(18);
+          const size = snap.size_bytes ? formatBytes(snap.size_bytes) : '?';
+
+          console.log(`  ${chalk.cyan(id)}${time}${machine}${chalk.dim(size)}`);
+        }
+
+        console.log(chalk.dim(`\n  Restore with: configsync pull --snapshot=<ID>`));
+      } catch (err: any) {
+        spinner.fail(`Failed to fetch history: ${err.message}`);
+        process.exit(1);
+      }
+    });
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -16,6 +16,8 @@ import { registerSyncCommand } from './sync.js';
 import { registerMachineCommand } from './machine.js';
 import { registerEnvCommand } from './env.js';
 import { registerProfileCommand } from './profile.js';
+import { registerHistoryCommand } from './history.js';
+import { registerWatchCommand } from './watch.js';
 
 export function registerCommands(program: Command): void {
   registerInitCommand(program);
@@ -35,4 +37,6 @@ export function registerCommands(program: Command): void {
   registerMachineCommand(program);
   registerEnvCommand(program);
   registerProfileCommand(program);
+  registerHistoryCommand(program);
+  registerWatchCommand(program);
 }

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -16,9 +16,11 @@ import { requireConfirmation } from '../lib/safety.js';
 import { renderBanner } from '../lib/banner.js';
 import { renderTemplate, buildContext } from '../lib/template.js';
 import { ProfileManager } from '../lib/profiles.js';
-import { scanPackages } from '../lib/packages.js';
+import { scanPackages, scanPackagesAsync } from '../lib/packages.js';
 import { diffPackages, formatDiff } from '../lib/package-diff.js';
 import { loadMappings } from '../lib/package-mappings.js';
+import { parseFilters, shouldInclude, isFilterActive, type Filter } from '../lib/filter.js';
+import { getRestoreLevels } from '../lib/dependency-graph.js';
 
 function resolveHome(p: string): string {
   return path.resolve(p.replace(/^~/, os.homedir()));
@@ -114,6 +116,258 @@ const INSTALL_CMDS: Record<string, (pkg: string) => string> = {
   winget: (pkg) => `winget install ${pkg}`,
 };
 
+// --- Dry-run preview ---
+
+async function printDryRun(
+  state: Record<string, any>,
+  config: any,
+  filters: Filter[],
+  envFilesToRestore: any[],
+  options: { packages?: boolean },
+): Promise<void> {
+  console.log(chalk.bold('\nDry run — no changes will be made.\n'));
+
+  if (shouldInclude('configs', undefined, filters) && state.configs?.length) {
+    console.log(chalk.bold(`  Configs (${state.configs.length}):`));
+    for (const c of state.configs) {
+      const exists = fs.existsSync(resolveHome(c.source));
+      console.log(`    ${c.source}  ${chalk.dim(exists ? '(overwrite)' : '(create)')}`);
+    }
+  }
+
+  if (shouldInclude('repos', undefined, filters) && state.repos?.length) {
+    console.log(chalk.bold(`\n  Repos (${state.repos.length}):`));
+    for (const r of state.repos) {
+      const exists = fs.existsSync(resolveHome(r.path));
+      console.log(`    ${r.path}  ${chalk.dim(exists ? '(pull)' : `(clone from ${r.url})`)}`);
+    }
+  }
+
+  if (shouldInclude('env_files', undefined, filters) && envFilesToRestore?.length) {
+    console.log(chalk.bold(`\n  Env files (${envFilesToRestore.length}):`));
+    for (const e of envFilesToRestore) {
+      const envPath = path.join(resolveHome(e.project_path), e.filename || '.env.local');
+      const exists = fs.existsSync(envPath);
+      console.log(`    ${e.project_path}/${e.filename || '.env.local'}  ${chalk.dim(exists ? '(overwrite)' : '(create)')}`);
+    }
+  }
+
+  if (shouldInclude('modules', undefined, filters) && state.modules?.length) {
+    console.log(chalk.bold(`\n  Modules (${state.modules.length}):`));
+    for (const m of state.modules) {
+      const fileCount = m.files?.length || 0;
+      console.log(`    ${m.name}  ${chalk.dim(`(${fileCount} file${fileCount !== 1 ? 's' : ''}`)}`);
+      for (const f of m.files || []) {
+        const exists = fs.existsSync(resolveHome(f.path));
+        console.log(`      ${f.path}  ${chalk.dim(exists ? '(overwrite)' : '(create)')}`);
+      }
+    }
+  }
+
+  if (shouldInclude('projects', undefined, filters) && state.projects?.length) {
+    console.log(chalk.bold(`\n  Projects (${state.projects.length}):`));
+    for (const p of state.projects) {
+      const secretCount = p.secrets?.length || 0;
+      const configCount = p.configs?.length || 0;
+      console.log(`    ${p.name}  ${chalk.dim(`(${secretCount} secrets, ${configCount} configs)`)}`);
+    }
+  }
+
+  if (shouldInclude('groups', undefined, filters) && state.groups?.length) {
+    console.log(chalk.bold(`\n  Groups (${state.groups.length}):`));
+    for (const g of state.groups) {
+      console.log(`    ${g.name}  ${chalk.dim(`(${g.projects?.length || 0} projects)`)}`);
+    }
+  }
+
+  if (shouldInclude('packages', undefined, filters) && state.packages?.length && options.packages !== false) {
+    try {
+      const localManagers = await scanPackagesAsync();
+      const mappings = loadMappings(config);
+      const diff = diffPackages(localManagers, state.packages, mappings);
+      let totalMissing = 0;
+      for (const pkgs of diff.missing.values()) totalMissing += pkgs.length;
+      if (totalMissing > 0) {
+        console.log(chalk.bold(`\n  Packages (${totalMissing} missing):`));
+        console.log(formatDiff(diff));
+      } else {
+        console.log(chalk.bold('\n  Packages:') + chalk.green(' all installed'));
+      }
+    } catch {
+      console.log(chalk.dim('\n  Packages: unable to scan'));
+    }
+  }
+
+  console.log('');
+}
+
+// --- Restore category functions (for dependency-graph-driven execution) ---
+
+interface RestoreContext {
+  state: Record<string, any>;
+  config: any;
+  configManager: ConfigManager;
+  cryptoManager: CryptoManager;
+  templateContext: any;
+  envFilesToRestore: any[];
+  activeEnvName: string | null | undefined;
+  activeProfile: any;
+  filters: Filter[];
+  filterGroup?: string;
+  filterProject?: string;
+  options: {
+    force: boolean;
+    packages?: boolean;
+    install?: boolean;
+    installYes?: boolean;
+  };
+  stats: {
+    configs: number;
+    envs: number;
+    projects: number;
+    groups: number;
+    injected: number;
+    repoStats: { cloned: number; updated: number };
+    warnings: string[];
+  };
+}
+
+function restoreConfigs(ctx: RestoreContext): void {
+  if (!shouldInclude('configs', undefined, ctx.filters)) return;
+  if (ctx.filterGroup || ctx.filterProject) return;
+
+  for (const entry of ctx.state.configs || []) {
+    const resolvedPath = resolveHome(entry.source);
+    if (fs.existsSync(resolvedPath) && !ctx.options.force) {
+      fs.copyFileSync(resolvedPath, path.join(ctx.configManager.backupDir, `${path.basename(resolvedPath)}.${Date.now()}.bak`));
+    }
+    fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
+    let content: Buffer = Buffer.from(entry.content, 'base64');
+    if (entry.encrypted) content = Buffer.from(ctx.cryptoManager.decrypt(content));
+
+    if (entry.template && !entry.encrypted) {
+      const rendered = renderTemplate(content.toString('utf-8'), ctx.templateContext);
+      content = Buffer.from(rendered, 'utf-8');
+    }
+
+    fs.writeFileSync(resolvedPath, content);
+    ctx.stats.configs++;
+  }
+}
+
+function restoreEnvFilesCategory(ctx: RestoreContext): void {
+  if (!shouldInclude('env_files', undefined, ctx.filters)) return;
+  if (ctx.filterGroup || ctx.filterProject) return;
+
+  for (const env of ctx.envFilesToRestore) {
+    const envPath = path.join(resolveHome(env.project_path), env.filename || '.env.local');
+    if (fs.existsSync(envPath) && !ctx.options.force) {
+      fs.copyFileSync(envPath, path.join(ctx.configManager.backupDir, `${path.basename(envPath)}.${Date.now()}.bak`));
+    }
+    fs.mkdirSync(path.dirname(envPath), { recursive: true });
+    let content: Buffer = Buffer.from(env.content, 'base64');
+    if (env.encrypted) content = Buffer.from(ctx.cryptoManager.decrypt(content));
+    fs.writeFileSync(envPath, content, { mode: 0o600 });
+    ctx.stats.envs++;
+  }
+}
+
+function restoreModulesCategory(ctx: RestoreContext): void {
+  if (!shouldInclude('modules', undefined, ctx.filters)) return;
+
+  for (const mod of ctx.state.modules || []) {
+    for (const file of mod.files || []) {
+      const filePath = resolveHome(file.path);
+      if (fs.existsSync(filePath) && !ctx.options.force) {
+        fs.copyFileSync(filePath, path.join(ctx.configManager.backupDir, `${path.basename(filePath)}.${Date.now()}.bak`));
+      }
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      let content: Buffer = Buffer.from(file.content, 'base64');
+      if (file.encrypted) content = Buffer.from(ctx.cryptoManager.decrypt(content));
+      fs.writeFileSync(filePath, content, { mode: 0o600 });
+    }
+  }
+}
+
+function restoreReposCategory(ctx: RestoreContext): void {
+  if (!shouldInclude('repos', undefined, ctx.filters)) return;
+  if (ctx.filterGroup || ctx.filterProject) return;
+
+  for (const repo of ctx.state.repos || []) {
+    cloneOrPullRepo(repo, resolveHome(repo.path), ctx.stats.repoStats, ctx.stats.warnings);
+    if (repo.has_uncommitted) {
+      ctx.stats.warnings.push(`${repo.path} had uncommitted changes on source machine`);
+    }
+  }
+}
+
+function restoreProjectsCategory(ctx: RestoreContext): void {
+  if (!shouldInclude('projects', undefined, ctx.filters)) return;
+  if (ctx.filterGroup) return;
+
+  for (const project of ctx.state.projects || []) {
+    if (ctx.filterProject && !project.name.toLowerCase().includes(ctx.filterProject)) continue;
+
+    const projectPath = resolveHome(project.path);
+    if (project.repo?.url) {
+      cloneOrPullRepo(project.repo, projectPath, ctx.stats.repoStats, ctx.stats.warnings);
+    }
+
+    const projectConfig = (ctx.config.projects || []).find((p: any) => p.name === project.name || resolveHome(p.path) === projectPath);
+    if (projectConfig?.inject_as_env) {
+      writeEnvInject(ctx.configManager.configDir, project, ctx.cryptoManager, ctx.activeEnvName, ctx.activeProfile?.env_overrides);
+      ctx.stats.injected++;
+    } else {
+      restoreFiles(project.secrets || [], projectPath, ctx.cryptoManager, ctx.configManager.backupDir, ctx.options.force, 0o600);
+    }
+
+    restoreFiles(project.configs || [], projectPath, ctx.cryptoManager, ctx.configManager.backupDir, ctx.options.force, undefined, ctx.templateContext);
+    ctx.stats.projects++;
+  }
+}
+
+function restoreGroupsCategory(ctx: RestoreContext): void {
+  if (!shouldInclude('groups', undefined, ctx.filters)) return;
+
+  for (const group of ctx.state.groups || []) {
+    if (ctx.filterGroup && !group.name.toLowerCase().includes(ctx.filterGroup)) continue;
+
+    for (const project of group.projects || []) {
+      if (ctx.filterProject && !project.name.toLowerCase().includes(ctx.filterProject)) continue;
+
+      const projectPath = resolveHome(project.path);
+      if (project.repo?.url) {
+        cloneOrPullRepo(project.repo, projectPath, ctx.stats.repoStats, ctx.stats.warnings);
+      }
+
+      const projectConfig = (ctx.config.projects || []).find((p: any) => p.name === project.name || resolveHome(p.path) === projectPath);
+      if (projectConfig?.inject_as_env) {
+        writeEnvInject(ctx.configManager.configDir, project, ctx.cryptoManager, ctx.activeEnvName, ctx.activeProfile?.env_overrides);
+        ctx.stats.injected++;
+      } else {
+        restoreFiles(project.secrets || [], projectPath, ctx.cryptoManager, ctx.configManager.backupDir, ctx.options.force, 0o600);
+      }
+
+      restoreFiles(project.configs || [], projectPath, ctx.cryptoManager, ctx.configManager.backupDir, ctx.options.force, undefined, ctx.templateContext);
+      ctx.stats.projects++;
+    }
+    ctx.stats.groups++;
+  }
+}
+
+// Category name → restore function mapping
+const RESTORE_FNS: Record<string, (ctx: RestoreContext) => void> = {
+  configs: restoreConfigs,
+  env_files: restoreEnvFilesCategory,
+  modules: restoreModulesCategory,
+  repos: restoreReposCategory,
+  projects: restoreProjectsCategory,
+  groups: restoreGroupsCategory,
+  packages: () => {}, // handled separately after restore
+};
+
+// --- Main command ---
+
 export function registerPullCommand(program: Command): void {
   program
     .command('pull')
@@ -129,6 +383,9 @@ export function registerPullCommand(program: Command): void {
     .option('--no-delete', 'pull cloud additions without removing local-only environments')
     .option('--cloud-wins', 'on conflict, prefer cloud version over local')
     .option('-y, --yes', 'skip confirmation prompt')
+    .option('--dry-run', 'preview what would be restored without making changes')
+    .option('--filter <filters...>', 'only pull specific items (e.g. modules:ssh,configs)')
+    .option('--snapshot <id>', 'restore a specific snapshot by ID')
     .option('--i-know-what-im-doing', 'override production safety (requires CONFIGSYNC_ALLOW_PROD_SKIP=1)')
     .action(async (options: {
       force: boolean;
@@ -138,10 +395,13 @@ export function registerPullCommand(program: Command): void {
       listMachines?: boolean;
       install?: boolean;
       installYes?: boolean;
-      packages?: boolean; // --no-packages sets this to false
+      packages?: boolean;
       noDelete?: boolean;
       cloudWins?: boolean;
       yes?: boolean;
+      dryRun?: boolean;
+      filter?: string[];
+      snapshot?: string;
       iKnowWhatImDoing?: boolean;
     }) => {
       const configManager = new ConfigManager();
@@ -156,7 +416,7 @@ export function registerPullCommand(program: Command): void {
       // Environment safety check
       const envManager = new EnvironmentManager(configManager.configDir);
       const activeEnv = envManager.getActive(config, program.opts().env);
-      if (activeEnv) {
+      if (activeEnv && !options.dryRun) {
         console.log(renderBanner(activeEnv));
         const operation = options.force ? 'pull-force' : 'pull';
         const confirmed = await requireConfirmation(activeEnv, operation as any, options);
@@ -203,81 +463,85 @@ export function registerPullCommand(program: Command): void {
             process.exit(0);
           }
 
-          let pullFromMachineId: string | undefined;
-          if (options.from) {
-            const machines = await backend.listMachines();
-            const match = machines.find((m: any) =>
-              m.machine_id === options.from ||
-              m.name.toLowerCase().includes(options.from!.toLowerCase())
-            );
-            if (!match) {
-              spinner.fail(`Machine "${options.from}" not found.`);
-              if (machines.length > 0) {
-                console.log(chalk.dim('\nAvailable machines:'));
-                for (const m of machines) {
-                  console.log(chalk.dim(`  - ${m.name} (${m.machine_id})`));
-                }
-              }
+          // Snapshot restore
+          if (options.snapshot) {
+            state = await backend.pullSnapshot(parseInt(options.snapshot, 10), cryptoManager);
+            if (!state) {
+              spinner.fail(`Snapshot #${options.snapshot} not found.`);
               process.exit(1);
             }
-            pullFromMachineId = match.machine_id;
-            spinner.text = `Pulling from ${match.name}...`;
-          }
-
-          state = await backend.pull(cryptoManager, pullFromMachineId);
-
-          // Merge cloud environments into local config
-          try {
-            const cloudEnvs = await backend.getEnvironments();
-            if (cloudEnvs.length > 0) {
-              if (!config.environments) config.environments = [];
-              const cloudByName = new Map(cloudEnvs.map((e: any) => [e.name, e]));
-              let added = 0;
-              let updated = 0;
-              let removed = 0;
-
-              // Add cloud-only envs to local; optionally overwrite on conflict
-              for (const cloudEnv of cloudEnvs) {
-                const local = config.environments.find(e => e.name === cloudEnv.name);
-                if (!local) {
-                  config.environments.push({
-                    name: cloudEnv.name,
-                    tier: cloudEnv.tier,
-                    color: cloudEnv.color,
-                    protect: !!cloudEnv.protect,
-                  });
-                  added++;
-                } else if (options.cloudWins) {
-                  local.tier = cloudEnv.tier;
-                  local.color = cloudEnv.color;
-                  local.protect = !!cloudEnv.protect;
-                  updated++;
-                }
-              }
-
-              // Remove local envs not in cloud (unless --no-delete)
-              if (!options.noDelete) {
-                const toRemove = config.environments.filter(e => !cloudByName.has(e.name));
-                for (const env of toRemove) {
-                  const idx = config.environments.indexOf(env);
-                  if (idx !== -1) {
-                    config.environments.splice(idx, 1);
-                    removed++;
+          } else {
+            let pullFromMachineId: string | undefined;
+            if (options.from) {
+              const machines = await backend.listMachines();
+              const match = machines.find((m: any) =>
+                m.machine_id === options.from ||
+                m.name.toLowerCase().includes(options.from!.toLowerCase())
+              );
+              if (!match) {
+                spinner.fail(`Machine "${options.from}" not found.`);
+                if (machines.length > 0) {
+                  console.log(chalk.dim('\nAvailable machines:'));
+                  for (const m of machines) {
+                    console.log(chalk.dim(`  - ${m.name} (${m.machine_id})`));
                   }
                 }
+                process.exit(1);
               }
-
-              if (added > 0 || updated > 0 || removed > 0) {
-                configManager.save(config);
-                const parts: string[] = [];
-                if (added) parts.push(`${added} added`);
-                if (updated) parts.push(`${updated} updated`);
-                if (removed) parts.push(`${removed} removed`);
-                spinner.text = `Environments: ${parts.join(', ')}`;
-              }
+              pullFromMachineId = match.machine_id;
+              spinner.text = `Pulling from ${match.name}...`;
             }
-          } catch {
-            // Environment sync is non-critical
+
+            state = await backend.pull(cryptoManager, pullFromMachineId);
+          }
+
+          // Merge cloud environments into local config (skip on dry-run)
+          if (!options.dryRun) {
+            try {
+              const cloudEnvs = await backend.getEnvironments();
+              if (cloudEnvs.length > 0) {
+                if (!config.environments) config.environments = [];
+                const cloudByName = new Map(cloudEnvs.map((e: any) => [e.name, e]));
+                let added = 0;
+                let updated = 0;
+                let removed = 0;
+
+                for (const cloudEnv of cloudEnvs) {
+                  const local = config.environments.find((e: any) => e.name === cloudEnv.name);
+                  if (!local) {
+                    config.environments.push({
+                      name: cloudEnv.name,
+                      tier: cloudEnv.tier,
+                      color: cloudEnv.color,
+                      protect: !!cloudEnv.protect,
+                    });
+                    added++;
+                  } else if (options.cloudWins) {
+                    local.tier = cloudEnv.tier;
+                    local.color = cloudEnv.color;
+                    local.protect = !!cloudEnv.protect;
+                    updated++;
+                  }
+                }
+
+                if (!options.noDelete) {
+                  const toRemove = config.environments.filter((e: any) => !cloudByName.has(e.name));
+                  for (const env of toRemove) {
+                    const idx = config.environments.indexOf(env);
+                    if (idx !== -1) {
+                      config.environments.splice(idx, 1);
+                      removed++;
+                    }
+                  }
+                }
+
+                if (added > 0 || updated > 0 || removed > 0) {
+                  configManager.save(config);
+                }
+              }
+            } catch {
+              // Environment sync is non-critical
+            }
           }
         } else {
           const stateFile = path.join(configManager.stateDir, 'state.json');
@@ -291,11 +555,6 @@ export function registerPullCommand(program: Command): void {
           process.exit(1);
         }
 
-        spinner.text = 'Restoring...';
-
-        // Build template context for this machine (profile vars override machine vars)
-        const templateContext = buildContext(config.machine, activeProfile);
-
         // Resolve environment-scoped env files
         const activeEnvName = activeEnv?.name || envManager.resolve(program.opts().env);
         let envFilesToRestore = state.env_files || [];
@@ -303,122 +562,69 @@ export function registerPullCommand(program: Command): void {
           envFilesToRestore = state.env_files_by_environment[activeEnvName];
         }
 
-        const repoStats = { cloned: 0, updated: 0 };
-        let configsRestored = 0;
-        let envsRestored = 0;
-        let projectsRestored = 0;
-        let groupsRestored = 0;
-        let injectedProjects = 0;
-        const warnings: string[] = [];
+        // Parse filters (--filter flag + legacy --group/--project shortcuts)
+        const filters = parseFilters(options.filter || []);
+
+        // Dry-run mode: preview only
+        if (options.dryRun) {
+          spinner.stop();
+          await printDryRun(state, config, filters, envFilesToRestore, options);
+          return;
+        }
+
+        spinner.text = 'Restoring...';
+
+        // Build template context
+        const templateContext = buildContext(config.machine, activeProfile);
 
         const filterGroup = options.group?.toLowerCase();
         const filterProject = options.project?.toLowerCase();
-        const isFiltered = !!(filterGroup || filterProject);
 
-        // If filtering by group/project, skip standalone items
-        if (!isFiltered) {
-          // Restore standalone config files
-          for (const entry of state.configs || []) {
-            const resolvedPath = resolveHome(entry.source);
-            if (fs.existsSync(resolvedPath) && !options.force) {
-              fs.copyFileSync(resolvedPath, path.join(configManager.backupDir, `${path.basename(resolvedPath)}.${Date.now()}.bak`));
-            }
-            fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
-            let content: Buffer = Buffer.from(entry.content, 'base64');
-            if (entry.encrypted) content = Buffer.from(cryptoManager.decrypt(content));
+        const ctx: RestoreContext = {
+          state,
+          config,
+          configManager,
+          cryptoManager,
+          templateContext,
+          envFilesToRestore,
+          activeEnvName,
+          activeProfile,
+          filters,
+          filterGroup,
+          filterProject,
+          options,
+          stats: {
+            configs: 0,
+            envs: 0,
+            projects: 0,
+            groups: 0,
+            injected: 0,
+            repoStats: { cloned: 0, updated: 0 },
+            warnings: [],
+          },
+        };
 
-            // Template rendering for non-encrypted config files
-            if (entry.template && !entry.encrypted) {
-              const rendered = renderTemplate(content.toString('utf-8'), templateContext);
-              content = Buffer.from(rendered, 'utf-8');
-            }
-
-            fs.writeFileSync(resolvedPath, content);
-            configsRestored++;
-          }
-
-          // Restore standalone repos
-          for (const repo of state.repos || []) {
-            cloneOrPullRepo(repo, resolveHome(repo.path), repoStats, warnings);
-            if (repo.has_uncommitted) {
-              warnings.push(`${repo.path} had uncommitted changes on source machine`);
-            }
-          }
-
-          // Restore standalone env files
-          for (const env of envFilesToRestore) {
-            const envPath = path.join(resolveHome(env.project_path), env.filename || '.env.local');
-            if (fs.existsSync(envPath) && !options.force) {
-              fs.copyFileSync(envPath, path.join(configManager.backupDir, `${path.basename(envPath)}.${Date.now()}.bak`));
-            }
-            fs.mkdirSync(path.dirname(envPath), { recursive: true });
-            let content: Buffer = Buffer.from(env.content, 'base64');
-            if (env.encrypted) content = Buffer.from(cryptoManager.decrypt(content));
-            fs.writeFileSync(envPath, content, { mode: 0o600 });
-            envsRestored++;
-          }
-        }
-
-        // Restore standalone projects (if not filtering by group, or if project name matches)
-        if (!filterGroup) {
-          for (const project of state.projects || []) {
-            if (filterProject && !project.name.toLowerCase().includes(filterProject)) continue;
-
-            const projectPath = resolveHome(project.path);
-            if (project.repo?.url) {
-              cloneOrPullRepo(project.repo, projectPath, repoStats, warnings);
-            }
-
-            // Check if this project should use env injection
-            const projectConfig = (config.projects || []).find(p => p.name === project.name || resolveHome(p.path) === projectPath);
-            if (projectConfig?.inject_as_env) {
-              // Write to env_inject directory instead of disk
-              writeEnvInject(configManager.configDir, project, cryptoManager, activeEnvName, activeProfile?.env_overrides);
-              injectedProjects++;
-            } else {
-              restoreFiles(project.secrets || [], projectPath, cryptoManager, configManager.backupDir, options.force, 0o600);
-            }
-
-            restoreFiles(project.configs || [], projectPath, cryptoManager, configManager.backupDir, options.force, undefined, templateContext);
-            projectsRestored++;
-          }
-        }
-
-        // Restore groups
-        for (const group of state.groups || []) {
-          if (filterGroup && !group.name.toLowerCase().includes(filterGroup)) continue;
-
-          for (const project of group.projects || []) {
-            if (filterProject && !project.name.toLowerCase().includes(filterProject)) continue;
-
-            const projectPath = resolveHome(project.path);
-            if (project.repo?.url) {
-              cloneOrPullRepo(project.repo, projectPath, repoStats, warnings);
-            }
-
-            const projectConfig = (config.projects || []).find(p => p.name === project.name || resolveHome(p.path) === projectPath);
-            if (projectConfig?.inject_as_env) {
-              writeEnvInject(configManager.configDir, project, cryptoManager, activeEnvName, activeProfile?.env_overrides);
-              injectedProjects++;
-            } else {
-              restoreFiles(project.secrets || [], projectPath, cryptoManager, configManager.backupDir, options.force, 0o600);
-            }
-
-            restoreFiles(project.configs || [], projectPath, cryptoManager, configManager.backupDir, options.force, undefined, templateContext);
-            projectsRestored++;
-          }
-          groupsRestored++;
+        // Execute restore in dependency-graph order
+        const levels = getRestoreLevels();
+        for (const level of levels) {
+          // Run all categories in this level in parallel
+          await Promise.all(
+            level.map(async (category) => {
+              const fn = RESTORE_FNS[category];
+              if (fn) fn(ctx);
+            }),
+          );
         }
 
         // Build summary
         const parts: string[] = [];
-        if (configsRestored) parts.push(`${configsRestored} config${configsRestored !== 1 ? 's' : ''}`);
-        if (repoStats.cloned) parts.push(`${repoStats.cloned} repo${repoStats.cloned !== 1 ? 's' : ''} cloned`);
-        if (repoStats.updated) parts.push(`${repoStats.updated} repo${repoStats.updated !== 1 ? 's' : ''} updated`);
-        if (envsRestored) parts.push(`${envsRestored} env file${envsRestored !== 1 ? 's' : ''}`);
-        if (projectsRestored) parts.push(`${projectsRestored} project${projectsRestored !== 1 ? 's' : ''}`);
-        if (groupsRestored) parts.push(`${groupsRestored} group${groupsRestored !== 1 ? 's' : ''}`);
-        if (injectedProjects) parts.push(`${injectedProjects} project${injectedProjects !== 1 ? 's' : ''} (env injected)`);
+        if (ctx.stats.configs) parts.push(`${ctx.stats.configs} config${ctx.stats.configs !== 1 ? 's' : ''}`);
+        if (ctx.stats.repoStats.cloned) parts.push(`${ctx.stats.repoStats.cloned} repo${ctx.stats.repoStats.cloned !== 1 ? 's' : ''} cloned`);
+        if (ctx.stats.repoStats.updated) parts.push(`${ctx.stats.repoStats.updated} repo${ctx.stats.repoStats.updated !== 1 ? 's' : ''} updated`);
+        if (ctx.stats.envs) parts.push(`${ctx.stats.envs} env file${ctx.stats.envs !== 1 ? 's' : ''}`);
+        if (ctx.stats.projects) parts.push(`${ctx.stats.projects} project${ctx.stats.projects !== 1 ? 's' : ''}`);
+        if (ctx.stats.groups) parts.push(`${ctx.stats.groups} group${ctx.stats.groups !== 1 ? 's' : ''}`);
+        if (ctx.stats.injected) parts.push(`${ctx.stats.injected} project${ctx.stats.injected !== 1 ? 's' : ''} (env injected)`);
 
         spinner.succeed(`Restored! (${parts.join(', ') || 'no changes'})`);
 
@@ -426,13 +632,13 @@ export function registerPullCommand(program: Command): void {
         if (state.message) console.log(`  ${chalk.dim('Message:')} ${state.message}`);
 
         // Package reconciliation
-        if (state.packages?.length && !isFiltered && options.packages !== false) {
+        if (shouldInclude('packages', undefined, filters) && state.packages?.length && !isFilterActive(filters.filter(f => f.type !== 'packages')) && options.packages !== false) {
           const totalPkgs = state.packages.reduce((s: number, m: any) => s + m.packages.length, 0);
           console.log(`\n  ${chalk.dim('Packages:')} ${totalPkgs} packages from ${state.packages.length} manager(s)`);
 
           if (options.install || options.installYes) {
             spinner.start('Scanning local packages...');
-            const localManagers = scanPackages();
+            const localManagers = await scanPackagesAsync();
             spinner.stop();
 
             const mappings = loadMappings(config);
@@ -446,17 +652,14 @@ export function registerPullCommand(program: Command): void {
             } else {
               console.log(formatDiff(diff));
 
-              // Build install commands
               const commands: string[] = [];
               for (const [manager, packages] of diff.missing) {
                 const cmdFn = INSTALL_CMDS[manager];
                 if (!cmdFn) continue;
 
                 if (manager === 'brew' || manager === 'apt' || manager === 'dnf' || manager === 'pacman') {
-                  // Batch install for system managers
                   commands.push(cmdFn(packages.join(' ')));
                 } else {
-                  // Individual install for language managers
                   for (const pkg of packages) {
                     commands.push(cmdFn(pkg));
                   }
@@ -480,7 +683,7 @@ export function registerPullCommand(program: Command): void {
                     try {
                       execSync(cmd, { stdio: 'inherit', timeout: 300000 });
                     } catch (err: any) {
-                      warnings.push(`Failed: ${cmd}`);
+                      ctx.stats.warnings.push(`Failed: ${cmd}`);
                     }
                   }
                 }
@@ -491,13 +694,13 @@ export function registerPullCommand(program: Command): void {
           }
         }
 
-        if (injectedProjects > 0) {
-          console.log(chalk.dim(`\n  Env vars injected for ${injectedProjects} project(s). Use "eval $(configsync env vars)" or the shell hook.`));
+        if (ctx.stats.injected > 0) {
+          console.log(chalk.dim(`\n  Env vars injected for ${ctx.stats.injected} project(s). Use "eval $(configsync env vars)" or the shell hook.`));
         }
 
-        if (warnings.length > 0) {
+        if (ctx.stats.warnings.length > 0) {
           console.log(chalk.yellow('\nWarnings:'));
-          for (const w of warnings) console.log(chalk.yellow(`  - ${w}`));
+          for (const w of ctx.stats.warnings) console.log(chalk.yellow(`  - ${w}`));
         }
       } catch (err: any) {
         spinner.fail(`Pull failed: ${err.message}`);
@@ -520,13 +723,11 @@ function writeEnvInject(
   const injectDir = path.join(configDir, 'env_inject');
   fs.mkdirSync(injectDir, { recursive: true });
 
-  // Parse decrypted secrets into key=value pairs
   const vars: Record<string, string> = {};
   for (const secret of project.secrets || []) {
     let content: Buffer = Buffer.from(secret.content, 'base64');
     if (secret.encrypted) content = Buffer.from(cryptoManager.decrypt(content));
 
-    // Parse .env format
     const lines = content.toString('utf-8').split('\n');
     for (const line of lines) {
       const trimmed = line.trim();
@@ -536,7 +737,6 @@ function writeEnvInject(
       const key = trimmed.slice(0, eqIdx).trim();
       if (!/^[A-Za-z_][A-Za-z_0-9]*$/.test(key)) continue;
       let value = trimmed.slice(eqIdx + 1).trim();
-      // Strip surrounding quotes
       if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
         value = value.slice(1, -1);
       }
@@ -544,7 +744,6 @@ function writeEnvInject(
     }
   }
 
-  // Apply profile env_overrides on top
   if (profileOverrides) {
     Object.assign(vars, profileOverrides);
   }

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
-import ora from 'ora';
+import ora, { type Ora } from 'ora';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -12,10 +12,463 @@ import { promptPassword } from '../lib/prompt.js';
 import { EnvironmentManager } from '../lib/environment.js';
 import { requireConfirmation } from '../lib/safety.js';
 import { renderBanner } from '../lib/banner.js';
+import { HashCacheManager, mergeWithPrevious, type HashCache } from '../lib/hash-cache.js';
+import { parseFilters, shouldInclude, type Filter } from '../lib/filter.js';
 
 function resolveHome(p: string): string {
   return path.resolve(p.replace(/^~/, os.homedir()));
 }
+
+// --- Capture functions (extracted for parallelism) ---
+
+function encryptFile(
+  filePath: string,
+  sourceKey: string,
+  cryptoManager: CryptoManager,
+  cache: HashCache,
+  hashCacheManager: HashCacheManager,
+  noCache: boolean,
+): { content: string; encrypted: true } {
+  if (!noCache) {
+    const result = hashCacheManager.check(filePath, sourceKey, cache);
+    if (!result.changed && result.cachedContent) {
+      return { content: result.cachedContent, encrypted: true };
+    }
+    // Changed or no cache entry — encrypt and update cache
+    const raw = fs.readFileSync(filePath);
+    const encrypted = Buffer.from(cryptoManager.encrypt(raw));
+    const base64 = encrypted.toString('base64');
+    hashCacheManager.update(cache, sourceKey, result.sha256, result.size, result.mtime, base64);
+    return { content: base64, encrypted: true };
+  }
+  // No cache mode — always encrypt
+  const raw = fs.readFileSync(filePath);
+  const encrypted = Buffer.from(cryptoManager.encrypt(raw));
+  return { content: encrypted.toString('base64'), encrypted: true };
+}
+
+async function captureConfigs(
+  configs: any[],
+  cryptoManager: CryptoManager,
+  cache: HashCache,
+  hashCacheManager: HashCacheManager,
+  noCache: boolean,
+): Promise<Record<string, any>[]> {
+  const results: Record<string, any>[] = [];
+  for (const item of configs) {
+    const resolvedPath = resolveHome(item.source);
+    if (!fs.existsSync(resolvedPath)) continue;
+    if (!fs.statSync(resolvedPath).isFile()) continue;
+
+    const { content, encrypted } = encryptFile(resolvedPath, `config:${item.source}`, cryptoManager, cache, hashCacheManager, noCache);
+    results.push({ source: item.source, content, encrypted });
+  }
+  return results;
+}
+
+async function captureRepos(repos: any[]): Promise<Record<string, any>[]> {
+  const results: Record<string, any>[] = [];
+  for (const repo of repos) {
+    const repoPath = resolveHome(repo.path);
+    const repoState: Record<string, any> = {
+      url: repo.url,
+      path: repo.path,
+      branch: repo.branch || 'main',
+      auto_pull: repo.auto_pull !== false,
+    };
+
+    if (fs.existsSync(path.join(repoPath, '.git'))) {
+      try {
+        repoState.current_branch = execSync('git branch --show-current', {
+          cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+        }).trim();
+        repoState.commit = execSync('git rev-parse HEAD', {
+          cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+        }).trim();
+        const status = execSync('git status --porcelain', {
+          cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        repoState.has_uncommitted = status.trim().length > 0;
+      } catch {
+        // Git commands failed, just save the config
+      }
+    }
+
+    results.push(repoState);
+  }
+  return results;
+}
+
+async function captureEnvFiles(
+  envFiles: any[],
+  cryptoManager: CryptoManager,
+  cache: HashCache,
+  hashCacheManager: HashCacheManager,
+  noCache: boolean,
+): Promise<Record<string, any>[]> {
+  const results: Record<string, any>[] = [];
+  for (const env of envFiles) {
+    const envPath = path.join(resolveHome(env.project_path), env.filename || '.env.local');
+    if (!fs.existsSync(envPath)) continue;
+
+    const sourceKey = `env:${env.project_path}/${env.filename || '.env.local'}`;
+    const { content, encrypted } = encryptFile(envPath, sourceKey, cryptoManager, cache, hashCacheManager, noCache);
+    results.push({
+      project_path: env.project_path,
+      filename: env.filename || '.env.local',
+      content,
+      encrypted,
+    });
+  }
+  return results;
+}
+
+function captureProjectFiles(
+  project: any,
+  cryptoManager: CryptoManager,
+  cache: HashCache,
+  hashCacheManager: HashCacheManager,
+  noCache: boolean,
+): Record<string, any> {
+  const projectPath = resolveHome(project.path);
+  const capturedProject: Record<string, any> = {
+    name: project.name,
+    path: project.path,
+    repo: project.repo || null,
+    secrets: [],
+    configs: [],
+  };
+
+  for (const secretName of project.secrets) {
+    const secretPath = path.join(projectPath, secretName);
+    if (!fs.existsSync(secretPath)) continue;
+    const sourceKey = `project:${project.name}:secret:${secretName}`;
+    const { content, encrypted } = encryptFile(secretPath, sourceKey, cryptoManager, cache, hashCacheManager, noCache);
+    capturedProject.secrets.push({ filename: secretName, content, encrypted });
+  }
+
+  for (const configName of project.configs) {
+    const configPath = path.join(projectPath, configName);
+    if (!fs.existsSync(configPath)) continue;
+    const sourceKey = `project:${project.name}:config:${configName}`;
+    const { content, encrypted } = encryptFile(configPath, sourceKey, cryptoManager, cache, hashCacheManager, noCache);
+    capturedProject.configs.push({ filename: configName, content, encrypted });
+  }
+
+  if (project.repo && fs.existsSync(path.join(projectPath, '.git'))) {
+    try {
+      capturedProject.repo.current_branch = execSync('git branch --show-current', {
+        cwd: projectPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+      capturedProject.repo.commit = execSync('git rev-parse HEAD', {
+        cwd: projectPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+    } catch {}
+  }
+
+  return capturedProject;
+}
+
+async function captureProjects(
+  projects: any[],
+  cryptoManager: CryptoManager,
+  cache: HashCache,
+  hashCacheManager: HashCacheManager,
+  noCache: boolean,
+): Promise<Record<string, any>[]> {
+  return projects.map(p => captureProjectFiles(p, cryptoManager, cache, hashCacheManager, noCache));
+}
+
+async function captureGroups(
+  groups: any[],
+  cryptoManager: CryptoManager,
+  cache: HashCache,
+  hashCacheManager: HashCacheManager,
+  noCache: boolean,
+): Promise<Record<string, any>[]> {
+  return groups.map(group => ({
+    name: group.name,
+    path: group.path,
+    projects: group.projects.map((p: any) => captureProjectFiles(p, cryptoManager, cache, hashCacheManager, noCache)),
+  }));
+}
+
+async function captureModules(
+  modules: any[],
+  cryptoManager: CryptoManager,
+  cache: HashCache,
+  hashCacheManager: HashCacheManager,
+  noCache: boolean,
+): Promise<Record<string, any>[]> {
+  const results: Record<string, any>[] = [];
+  for (const mod of modules) {
+    const capturedMod: Record<string, any> = {
+      name: mod.name,
+      files: [],
+      extras: mod.extras || null,
+    };
+
+    for (const file of mod.files) {
+      const filePath = file.path.replace(/^~/, os.homedir());
+      const resolvedPath = path.resolve(filePath);
+      if (!fs.existsSync(resolvedPath)) continue;
+      if (!fs.statSync(resolvedPath).isFile()) continue;
+
+      const sourceKey = `module:${mod.name}:${file.path}`;
+      const { content, encrypted } = encryptFile(resolvedPath, sourceKey, cryptoManager, cache, hashCacheManager, noCache);
+      capturedMod.files.push({ path: file.path, content, encrypted });
+    }
+
+    results.push(capturedMod);
+  }
+  return results;
+}
+
+function captureEnvVars(envVarNames: string[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const varName of envVarNames) {
+    const value = process.env[varName];
+    if (value !== undefined) {
+      result[varName] = value;
+    }
+  }
+  return result;
+}
+
+// --- Core push logic (exported for watch mode) ---
+
+export interface PushOptions {
+  message?: string;
+  yes?: boolean;
+  noDelete?: boolean;
+  iKnowWhatImDoing?: boolean;
+  noCache?: boolean;
+  filter?: string[];
+  changed?: boolean;
+}
+
+export interface PushStats {
+  configs: number;
+  repos: number;
+  envFiles: number;
+  projects: number;
+  groups: number;
+  modules: number;
+}
+
+export async function performPush(
+  config: any,
+  configManager: ConfigManager,
+  cryptoManager: CryptoManager,
+  envManager: EnvironmentManager,
+  program: Command,
+  options: PushOptions,
+  spinner?: Ora,
+): Promise<PushStats> {
+  const hashCacheManager = new HashCacheManager(configManager.stateDir);
+  const cache = hashCacheManager.load();
+  const noCache = !!options.noCache;
+  const filters = parseFilters(options.filter || []);
+
+  // Parallel capture of independent sections
+  const [capturedConfigs, capturedEnvFiles, capturedModules] = await Promise.all([
+    shouldInclude('configs', undefined, filters)
+      ? captureConfigs(config.configs, cryptoManager, cache, hashCacheManager, noCache)
+      : Promise.resolve([]),
+    shouldInclude('env_files', undefined, filters)
+      ? captureEnvFiles(config.env_files, cryptoManager, cache, hashCacheManager, noCache)
+      : Promise.resolve([]),
+    shouldInclude('modules', undefined, filters)
+      ? captureModules(config.modules || [], cryptoManager, cache, hashCacheManager, noCache)
+      : Promise.resolve([]),
+  ]);
+
+  // Repos use execSync (blocking) — run after parallel batch
+  const capturedRepos = shouldInclude('repos', undefined, filters)
+    ? await captureRepos(config.repos)
+    : [];
+
+  // Projects and groups can run in parallel with each other
+  const [capturedProjects, capturedGroups] = await Promise.all([
+    shouldInclude('projects', undefined, filters)
+      ? captureProjects(config.projects || [], cryptoManager, cache, hashCacheManager, noCache)
+      : Promise.resolve([]),
+    shouldInclude('groups', undefined, filters)
+      ? captureGroups(config.groups || [], cryptoManager, cache, hashCacheManager, noCache)
+      : Promise.resolve([]),
+  ]);
+
+  const capturedEnvVars = captureEnvVars(config.env_vars || []);
+
+  // Environment-scoped secrets
+  const activeEnv = envManager.getActive(config, program.opts().env);
+  const activeEnvName = activeEnv?.name || envManager.resolve(program.opts().env);
+  const envFilesByEnvironment: Record<string, any[]> = {};
+  if (activeEnvName) {
+    envFilesByEnvironment[activeEnvName] = capturedEnvFiles;
+  }
+
+  let state: Record<string, any> = {
+    timestamp: new Date().toISOString(),
+    message: options.message || '',
+    active_environment: activeEnvName || null,
+    configs: capturedConfigs,
+    repos: capturedRepos,
+    env_files: activeEnvName ? [] : capturedEnvFiles,
+    env_files_by_environment: envFilesByEnvironment,
+    packages: config.packages || [],
+    projects: capturedProjects,
+    groups: capturedGroups,
+    modules: capturedModules,
+    env_vars: capturedEnvVars,
+    machine_vars: config.machine || null,
+    profiles: config.profiles || [],
+  };
+
+  // --changed: merge with previous state for unchanged items
+  if (options.changed) {
+    let previousState: Record<string, any> | null = null;
+    if (config.sync.backend === 'cloud') {
+      const apiUrl = config.sync.config.api_url;
+      const apiKey = config.sync.config.api_key;
+      if (apiUrl && apiKey) {
+        const backend = new CloudBackend(apiUrl, apiKey);
+        previousState = await backend.pull(cryptoManager);
+      }
+    } else {
+      const stateFile = path.join(configManager.stateDir, 'state.json');
+      if (fs.existsSync(stateFile)) {
+        previousState = JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
+      }
+    }
+    if (previousState) {
+      state.configs = mergeWithPrevious(capturedConfigs, previousState.configs || [], 'source');
+      state.repos = mergeWithPrevious(capturedRepos, previousState.repos || [], 'path');
+      state.env_files = mergeWithPrevious(
+        activeEnvName ? [] : capturedEnvFiles,
+        previousState.env_files || [],
+        'project_path',
+      );
+      state.modules = mergeWithPrevious(capturedModules, previousState.modules || [], 'name');
+      state.projects = mergeWithPrevious(capturedProjects, previousState.projects || [], 'name');
+      state.groups = mergeWithPrevious(capturedGroups, previousState.groups || [], 'name');
+    }
+  }
+
+  const metadata = {
+    timestamp: state.timestamp,
+    configs: capturedConfigs.map((c: any) => ({ source: c.source, encrypted: !!c.encrypted })),
+    repos: capturedRepos.map((r: any) => ({ url: r.url, path: r.path, branch: r.branch || r.current_branch })),
+    env_files: capturedEnvFiles.map((e: any) => ({ project_path: e.project_path, filename: e.filename })),
+    packages: (config.packages || []).map((p: any) => ({
+      manager: p.manager,
+      displayName: p.displayName,
+      count: p.packages.length,
+      items: p.packages,
+    })),
+    projects: (config.projects || []).map((p: any) => ({
+      name: p.name,
+      path: p.path,
+      repo: p.repo || null,
+      secrets: p.secrets,
+      configs: p.configs,
+    })),
+    groups: (config.groups || []).map((g: any) => ({
+      name: g.name,
+      path: g.path,
+      projects: g.projects.map((p: any) => ({
+        name: p.name,
+        path: p.path,
+        repo: p.repo || null,
+        secrets: p.secrets,
+        configs: p.configs,
+      })),
+    })),
+    modules: (config.modules || []).map((m: any) => ({
+      name: m.name,
+      files: m.files.map((f: any) => ({ path: f.path, encrypt: f.encrypt })),
+      extras: m.extras || null,
+    })),
+    environments: (config.environments || []).map((e: any) => ({
+      name: e.name,
+      tier: e.tier,
+      label: e.label || null,
+      color: e.color || null,
+      api_url: e.api_url || null,
+      protect: !!e.protect,
+    })),
+    env_vars: Object.keys(capturedEnvVars),
+    machine_vars: config.machine || null,
+    active_environment: activeEnvName || null,
+    profiles: (config.profiles || []).map((p: any) => ({
+      name: p.name,
+      environment: p.environment || null,
+      paths: p.paths || [],
+      vars: p.vars || {},
+      env_overrides: p.env_overrides ? Object.keys(p.env_overrides).reduce((acc: Record<string, string>, k: string) => { acc[k] = '***'; return acc; }, {}) : {},
+      description: p.description || null,
+    })),
+  };
+
+  if (config.sync.backend === 'cloud') {
+    const apiUrl = config.sync.config.api_url;
+    const apiKey = config.sync.config.api_key;
+
+    if (!apiUrl || !apiKey) {
+      throw new Error('Cloud backend not configured. Run "configsync login" first.');
+    }
+
+    const backend = new CloudBackend(apiUrl, apiKey);
+    await backend.registerMachine();
+    await backend.push(state, cryptoManager, metadata);
+
+    // Sync environments: push local → cloud, merge cloud-only back to local
+    if (config.environments && config.environments.length > 0) {
+      const merged = await backend.syncEnvironments(
+        config.environments.map((e: any) => ({
+          name: e.name,
+          tier: e.tier,
+          color: e.color || null,
+          protect: !!e.protect,
+        })),
+        { deleteCloudOnly: !options.noDelete },
+      );
+      const localNames = new Set((config.environments || []).map((e: any) => e.name));
+      let newFromCloud = 0;
+      for (const cloudEnv of merged) {
+        if (!localNames.has(cloudEnv.name)) {
+          config.environments.push({
+            name: cloudEnv.name,
+            tier: cloudEnv.tier,
+            color: cloudEnv.color,
+            protect: !!cloudEnv.protect,
+          });
+          newFromCloud++;
+        }
+      }
+      if (newFromCloud > 0) {
+        configManager.save(config);
+      }
+    }
+  } else {
+    const stateFile = path.join(configManager.stateDir, 'state.json');
+    fs.writeFileSync(stateFile, JSON.stringify(state, null, 2));
+  }
+
+  // Save hash cache after successful push
+  hashCacheManager.save(cache);
+
+  return {
+    configs: capturedConfigs.length,
+    repos: capturedRepos.length,
+    envFiles: capturedEnvFiles.length,
+    projects: capturedProjects.length,
+    groups: capturedGroups.length,
+    modules: capturedModules.length,
+  };
+}
+
+// --- Command registration ---
 
 export function registerPushCommand(program: Command): void {
   program
@@ -24,8 +477,11 @@ export function registerPushCommand(program: Command): void {
     .option('-m, --message <msg>', 'message describing this snapshot')
     .option('-y, --yes', 'skip confirmation prompt')
     .option('--no-delete', 'push local additions without removing cloud-only environments')
+    .option('--no-cache', 'skip hash cache and re-encrypt all files')
+    .option('--filter <filters...>', 'only push specific items (e.g. modules:ssh,configs)')
+    .option('--changed', 'only push items changed since last push')
     .option('--i-know-what-im-doing', 'override production safety (requires CONFIGSYNC_ALLOW_PROD_SKIP=1)')
-    .action(async (options: { message?: string; yes?: boolean; noDelete?: boolean; iKnowWhatImDoing?: boolean }) => {
+    .action(async (options: PushOptions) => {
       const configManager = new ConfigManager();
 
       if (!configManager.exists()) {
@@ -53,341 +509,15 @@ export function registerPushCommand(program: Command): void {
       const spinner = ora('Pushing state...').start();
 
       try {
-        // Capture config files
-        const capturedConfigs: Record<string, any>[] = [];
-        for (const item of config.configs) {
-          const resolvedPath = resolveHome(item.source);
-          if (!fs.existsSync(resolvedPath)) continue;
-          if (!fs.statSync(resolvedPath).isFile()) continue;
-
-          let content: Buffer = Buffer.from(fs.readFileSync(resolvedPath));
-          content = Buffer.from(cryptoManager.encrypt(content));
-
-          capturedConfigs.push({
-            source: item.source,
-            content: content.toString('base64'),
-            encrypted: true,
-          });
-        }
-
-        // Capture repo metadata (URL, branch, path — not the actual files)
-        const capturedRepos: Record<string, any>[] = [];
-        for (const repo of config.repos) {
-          const repoPath = resolveHome(repo.path);
-          const repoState: Record<string, any> = {
-            url: repo.url,
-            path: repo.path,
-            branch: repo.branch || 'main',
-            auto_pull: repo.auto_pull !== false,
-          };
-
-          // If the repo exists locally, capture current branch and commit
-          if (fs.existsSync(path.join(repoPath, '.git'))) {
-            try {
-              repoState.current_branch = execSync('git branch --show-current', {
-                cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
-              }).trim();
-              repoState.commit = execSync('git rev-parse HEAD', {
-                cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
-              }).trim();
-              const status = execSync('git status --porcelain', {
-                cwd: repoPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
-              });
-              repoState.has_uncommitted = status.trim().length > 0;
-            } catch {
-              // Git commands failed, just save the config
-            }
-          }
-
-          capturedRepos.push(repoState);
-        }
-
-        // Capture env files (always encrypted)
-        const capturedEnvFiles: Record<string, any>[] = [];
-        for (const env of config.env_files) {
-          const envPath = path.join(resolveHome(env.project_path), env.filename || '.env.local');
-          if (!fs.existsSync(envPath)) continue;
-
-          let content: Buffer = Buffer.from(fs.readFileSync(envPath));
-          content = Buffer.from(cryptoManager.encrypt(content));
-
-          capturedEnvFiles.push({
-            project_path: env.project_path,
-            filename: env.filename || '.env.local',
-            content: content.toString('base64'),
-            encrypted: true,
-          });
-        }
-
-        // Capture projects
-        const capturedProjects: Record<string, any>[] = [];
-        for (const project of config.projects || []) {
-          const projectPath = resolveHome(project.path);
-          const capturedProject: Record<string, any> = {
-            name: project.name,
-            path: project.path,
-            repo: project.repo || null,
-            secrets: [],
-            configs: [],
-          };
-
-          // Capture project secrets (encrypted)
-          for (const secretName of project.secrets) {
-            const secretPath = path.join(projectPath, secretName);
-            if (!fs.existsSync(secretPath)) continue;
-            let content: Buffer = Buffer.from(fs.readFileSync(secretPath));
-            content = Buffer.from(cryptoManager.encrypt(content));
-            capturedProject.secrets.push({
-              filename: secretName,
-              content: content.toString('base64'),
-              encrypted: true,
-            });
-          }
-
-          // Capture project configs (all encrypted)
-          for (const configName of project.configs) {
-            const configPath = path.join(projectPath, configName);
-            if (!fs.existsSync(configPath)) continue;
-            let content: Buffer = Buffer.from(fs.readFileSync(configPath));
-            content = Buffer.from(cryptoManager.encrypt(content));
-            capturedProject.configs.push({
-              filename: configName,
-              content: content.toString('base64'),
-              encrypted: true,
-            });
-          }
-
-          // Capture repo state if exists
-          if (project.repo && fs.existsSync(path.join(projectPath, '.git'))) {
-            try {
-              capturedProject.repo.current_branch = execSync('git branch --show-current', {
-                cwd: projectPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
-              }).trim();
-              capturedProject.repo.commit = execSync('git rev-parse HEAD', {
-                cwd: projectPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
-              }).trim();
-            } catch {}
-          }
-
-          capturedProjects.push(capturedProject);
-        }
-
-        // Capture groups (each group contains multiple projects)
-        const capturedGroups: Record<string, any>[] = [];
-        for (const group of config.groups || []) {
-          const capturedGroup: Record<string, any> = {
-            name: group.name,
-            path: group.path,
-            projects: [],
-          };
-
-          for (const project of group.projects) {
-            const projectPath = resolveHome(project.path);
-            const cp: Record<string, any> = {
-              name: project.name,
-              path: project.path,
-              repo: project.repo || null,
-              secrets: [],
-              configs: [],
-            };
-
-            for (const secretName of project.secrets) {
-              const secretPath = path.join(projectPath, secretName);
-              if (!fs.existsSync(secretPath)) continue;
-              let content: Buffer = Buffer.from(fs.readFileSync(secretPath));
-              content = Buffer.from(cryptoManager.encrypt(content));
-              cp.secrets.push({ filename: secretName, content: content.toString('base64'), encrypted: true });
-            }
-
-            for (const configName of project.configs) {
-              const configPath = path.join(projectPath, configName);
-              if (!fs.existsSync(configPath)) continue;
-              cp.configs.push({ filename: configName, content: Buffer.from(cryptoManager.encrypt(Buffer.from(fs.readFileSync(configPath)))).toString('base64'), encrypted: true });
-            }
-
-            if (project.repo && fs.existsSync(path.join(projectPath, '.git'))) {
-              try {
-                cp.repo.current_branch = execSync('git branch --show-current', { cwd: projectPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-                cp.repo.commit = execSync('git rev-parse HEAD', { cwd: projectPath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-              } catch {}
-            }
-
-            capturedGroup.projects.push(cp);
-          }
-
-          capturedGroups.push(capturedGroup);
-        }
-
-        // Capture modules
-        const capturedModules: Record<string, any>[] = [];
-        for (const mod of config.modules || []) {
-          const capturedMod: Record<string, any> = {
-            name: mod.name,
-            files: [],
-            extras: mod.extras || null,
-          };
-
-          for (const file of mod.files) {
-            const filePath = file.path.replace(/^~/, os.homedir());
-            const resolvedPath = path.resolve(filePath);
-            if (!fs.existsSync(resolvedPath)) continue;
-            if (!fs.statSync(resolvedPath).isFile()) continue;
-
-            let content: Buffer = Buffer.from(fs.readFileSync(resolvedPath));
-            content = Buffer.from(cryptoManager.encrypt(content));
-
-            capturedMod.files.push({
-              path: file.path,
-              content: content.toString('base64'),
-              encrypted: true,
-            });
-          }
-
-          capturedModules.push(capturedMod);
-        }
-
-        // Capture tracked env vars
-        const capturedEnvVars: Record<string, string> = {};
-        for (const varName of config.env_vars || []) {
-          const value = process.env[varName];
-          if (value !== undefined) {
-            capturedEnvVars[varName] = value;
-          }
-        }
-
-        // Environment-scoped secrets
-        const activeEnvName = activeEnv?.name || envManager.resolve(program.opts().env);
-        const envFilesByEnvironment: Record<string, any[]> = {};
-        if (activeEnvName) {
-          envFilesByEnvironment[activeEnvName] = capturedEnvFiles;
-        }
-
-        const state: Record<string, any> = {
-          timestamp: new Date().toISOString(),
-          message: options.message || '',
-          active_environment: activeEnvName || null,
-          configs: capturedConfigs,
-          repos: capturedRepos,
-          env_files: activeEnvName ? [] : capturedEnvFiles,
-          env_files_by_environment: envFilesByEnvironment,
-          packages: config.packages || [],
-          projects: capturedProjects,
-          groups: capturedGroups,
-          modules: capturedModules,
-          env_vars: capturedEnvVars,
-          machine_vars: config.machine || null,
-          profiles: config.profiles || [],
-        };
-
-        const metadata = {
-          timestamp: state.timestamp,
-          configs: capturedConfigs.map((c: any) => ({ source: c.source, encrypted: !!c.encrypted })),
-          repos: capturedRepos.map((r: any) => ({ url: r.url, path: r.path, branch: r.branch || r.current_branch })),
-          env_files: capturedEnvFiles.map((e: any) => ({ project_path: e.project_path, filename: e.filename })),
-          packages: (config.packages || []).map((p: any) => ({
-            manager: p.manager,
-            displayName: p.displayName,
-            count: p.packages.length,
-            items: p.packages,
-          })),
-          projects: (config.projects || []).map((p: any) => ({
-            name: p.name,
-            path: p.path,
-            repo: p.repo || null,
-            secrets: p.secrets,
-            configs: p.configs,
-          })),
-          groups: (config.groups || []).map((g: any) => ({
-            name: g.name,
-            path: g.path,
-            projects: g.projects.map((p: any) => ({
-              name: p.name,
-              path: p.path,
-              repo: p.repo || null,
-              secrets: p.secrets,
-              configs: p.configs,
-            })),
-          })),
-          modules: (config.modules || []).map((m: any) => ({
-            name: m.name,
-            files: m.files.map((f: any) => ({ path: f.path, encrypt: f.encrypt })),
-            extras: m.extras || null,
-          })),
-          environments: (config.environments || []).map((e: any) => ({
-            name: e.name,
-            tier: e.tier,
-            label: e.label || null,
-            color: e.color || null,
-            api_url: e.api_url || null,
-            protect: !!e.protect,
-          })),
-          env_vars: Object.keys(capturedEnvVars),
-          machine_vars: config.machine || null,
-          active_environment: activeEnvName || null,
-          profiles: (config.profiles || []).map((p: any) => ({
-            name: p.name,
-            environment: p.environment || null,
-            paths: p.paths || [],
-            vars: p.vars || {},
-            env_overrides: p.env_overrides ? Object.keys(p.env_overrides).reduce((acc: Record<string, string>, k: string) => { acc[k] = '***'; return acc; }, {}) : {},
-            description: p.description || null,
-          })),
-        };
-
-        if (config.sync.backend === 'cloud') {
-          const apiUrl = config.sync.config.api_url;
-          const apiKey = config.sync.config.api_key;
-
-          if (!apiUrl || !apiKey) {
-            spinner.fail('Cloud backend not configured. Run "configsync login" first.');
-            process.exit(1);
-          }
-
-          const backend = new CloudBackend(apiUrl, apiKey);
-          await backend.registerMachine();
-          await backend.push(state, cryptoManager, metadata);
-
-          // Sync environments: push local → cloud, merge cloud-only back to local
-          if (config.environments && config.environments.length > 0) {
-            const merged = await backend.syncEnvironments(
-              config.environments.map(e => ({
-                name: e.name,
-                tier: e.tier,
-                color: e.color || null,
-                protect: !!e.protect,
-              })),
-              { deleteCloudOnly: !options.noDelete },
-            );
-            // Merge cloud-only environments back into local config
-            const localNames = new Set((config.environments || []).map(e => e.name));
-            let newFromCloud = 0;
-            for (const cloudEnv of merged) {
-              if (!localNames.has(cloudEnv.name)) {
-                config.environments.push({
-                  name: cloudEnv.name,
-                  tier: cloudEnv.tier,
-                  color: cloudEnv.color,
-                  protect: !!cloudEnv.protect,
-                });
-                newFromCloud++;
-              }
-            }
-            if (newFromCloud > 0) {
-              configManager.save(config);
-            }
-          }
-        } else {
-          const stateFile = path.join(configManager.stateDir, 'state.json');
-          fs.writeFileSync(stateFile, JSON.stringify(state, null, 2));
-        }
+        const stats = await performPush(config, configManager, cryptoManager, envManager, program, options, spinner);
 
         const parts = [
-          `${capturedConfigs.length} config${capturedConfigs.length !== 1 ? 's' : ''}`,
-          `${capturedRepos.length} repo${capturedRepos.length !== 1 ? 's' : ''}`,
-          `${capturedEnvFiles.length} env file${capturedEnvFiles.length !== 1 ? 's' : ''}`,
-          `${capturedProjects.length} project${capturedProjects.length !== 1 ? 's' : ''}`,
-          `${capturedGroups.length} group${capturedGroups.length !== 1 ? 's' : ''}`,
-          `${capturedModules.length} module${capturedModules.length !== 1 ? 's' : ''}`,
+          `${stats.configs} config${stats.configs !== 1 ? 's' : ''}`,
+          `${stats.repos} repo${stats.repos !== 1 ? 's' : ''}`,
+          `${stats.envFiles} env file${stats.envFiles !== 1 ? 's' : ''}`,
+          `${stats.projects} project${stats.projects !== 1 ? 's' : ''}`,
+          `${stats.groups} group${stats.groups !== 1 ? 's' : ''}`,
+          `${stats.modules} module${stats.modules !== 1 ? 's' : ''}`,
         ].filter(p => !p.startsWith('0'));
 
         spinner.succeed(`State pushed! (${parts.join(', ')})`);

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -1,0 +1,185 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { ConfigManager } from '../lib/config.js';
+import CryptoManager from '../lib/crypto.js';
+import { promptPassword } from '../lib/prompt.js';
+import { EnvironmentManager } from '../lib/environment.js';
+import { performPush } from './push.js';
+import { parseFilters, shouldInclude } from '../lib/filter.js';
+
+function resolveHome(p: string): string {
+  return path.resolve(p.replace(/^~/, os.homedir()));
+}
+
+export function registerWatchCommand(program: Command): void {
+  program
+    .command('watch')
+    .description('Watch tracked files and auto-push on changes')
+    .option('--debounce <ms>', 'debounce delay in milliseconds', '5000')
+    .option('--filter <filters...>', 'only watch specific items')
+    .option('-m, --message <msg>', 'message for auto-pushed snapshots')
+    .action(async (options: { debounce: string; filter?: string[]; message?: string }) => {
+      const configManager = new ConfigManager();
+
+      if (!configManager.exists()) {
+        console.error(chalk.red("Error: Run 'configsync init' first."));
+        process.exit(1);
+      }
+
+      const config = configManager.load();
+
+      const password = await promptPassword('Enter master password: ');
+      const cryptoManager = new CryptoManager(configManager.configDir);
+      cryptoManager.unlock(password);
+
+      const envManager = new EnvironmentManager(configManager.configDir);
+      const debounceMs = parseInt(options.debounce, 10) || 5000;
+      const filters = parseFilters(options.filter || []);
+
+      // Collect all tracked file paths
+      const watchPaths: string[] = [];
+
+      if (shouldInclude('configs', undefined, filters)) {
+        for (const item of config.configs || []) {
+          const p = resolveHome(item.source);
+          if (fs.existsSync(p)) watchPaths.push(p);
+        }
+      }
+
+      if (shouldInclude('env_files', undefined, filters)) {
+        for (const env of config.env_files || []) {
+          const p = path.join(resolveHome(env.project_path), env.filename || '.env.local');
+          if (fs.existsSync(p)) watchPaths.push(p);
+        }
+      }
+
+      if (shouldInclude('modules', undefined, filters)) {
+        for (const mod of config.modules || []) {
+          for (const file of mod.files || []) {
+            const p = resolveHome(file.path);
+            if (fs.existsSync(p)) watchPaths.push(p);
+          }
+        }
+      }
+
+      if (shouldInclude('projects', undefined, filters)) {
+        for (const project of config.projects || []) {
+          const projectPath = resolveHome(project.path);
+          for (const s of project.secrets || []) {
+            const p = path.join(projectPath, s);
+            if (fs.existsSync(p)) watchPaths.push(p);
+          }
+          for (const c of project.configs || []) {
+            const p = path.join(projectPath, c);
+            if (fs.existsSync(p)) watchPaths.push(p);
+          }
+        }
+      }
+
+      if (shouldInclude('groups', undefined, filters)) {
+        for (const group of config.groups || []) {
+          for (const project of group.projects || []) {
+            const projectPath = resolveHome(project.path);
+            for (const s of project.secrets || []) {
+              const p = path.join(projectPath, s);
+              if (fs.existsSync(p)) watchPaths.push(p);
+            }
+            for (const c of project.configs || []) {
+              const p = path.join(projectPath, c);
+              if (fs.existsSync(p)) watchPaths.push(p);
+            }
+          }
+        }
+      }
+
+      if (watchPaths.length === 0) {
+        console.error(chalk.red('No files to watch.'));
+        process.exit(1);
+      }
+
+      // Deduplicate
+      const uniquePaths = [...new Set(watchPaths)];
+
+      console.log(chalk.bold(`Watching ${uniquePaths.length} file${uniquePaths.length !== 1 ? 's' : ''} for changes...`));
+      console.log(chalk.dim(`  Debounce: ${debounceMs}ms`));
+      console.log(chalk.dim('  Press Ctrl+C to stop.\n'));
+
+      let debounceTimer: NodeJS.Timeout | null = null;
+      let pushing = false;
+      let lastPush = '';
+      const watchers: fs.FSWatcher[] = [];
+
+      async function doPush(): Promise<void> {
+        if (pushing) return;
+        pushing = true;
+
+        try {
+          const freshConfig = configManager.load();
+          const stats = await performPush(
+            freshConfig,
+            configManager,
+            cryptoManager,
+            envManager,
+            program,
+            {
+              message: options.message || `auto-push from watch`,
+              filter: options.filter,
+              changed: true,  // Only push what changed
+            },
+          );
+
+          lastPush = new Date().toLocaleTimeString();
+          const parts = [
+            stats.configs && `${stats.configs} configs`,
+            stats.repos && `${stats.repos} repos`,
+            stats.envFiles && `${stats.envFiles} env files`,
+            stats.projects && `${stats.projects} projects`,
+            stats.groups && `${stats.groups} groups`,
+            stats.modules && `${stats.modules} modules`,
+          ].filter(Boolean);
+
+          console.log(chalk.green(`  [${lastPush}] Pushed: ${parts.join(', ') || 'no changes'}`));
+        } catch (err: any) {
+          console.error(chalk.red(`  [${new Date().toLocaleTimeString()}] Push failed: ${err.message}`));
+        } finally {
+          pushing = false;
+        }
+      }
+
+      function onFileChange(filename: string | null): void {
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => {
+          console.log(chalk.dim(`  Change detected${filename ? `: ${filename}` : ''}...`));
+          doPush();
+        }, debounceMs);
+      }
+
+      // Set up watchers
+      for (const filePath of uniquePaths) {
+        try {
+          const watcher = fs.watch(filePath, (event, filename) => {
+            onFileChange(filename || path.basename(filePath));
+          });
+          watchers.push(watcher);
+        } catch {
+          // File may have been deleted between check and watch
+        }
+      }
+
+      // Graceful shutdown
+      const cleanup = (): void => {
+        console.log(chalk.dim('\n  Stopping watchers...'));
+        if (debounceTimer) clearTimeout(debounceTimer);
+        for (const w of watchers) {
+          try { w.close(); } catch {}
+        }
+        process.exit(0);
+      };
+
+      process.on('SIGINT', cleanup);
+      process.on('SIGTERM', cleanup);
+    });
+}

--- a/src/lib/cloud.ts
+++ b/src/lib/cloud.ts
@@ -141,6 +141,29 @@ class CloudBackend {
     return data.environments || [];
   }
 
+  async getHistory(machineId?: string, limit = 20): Promise<any[]> {
+    const params = new URLSearchParams({ limit: String(limit) });
+    if (machineId) params.set('machine_id', machineId);
+    const response = await this.request('GET', `/api/machines/history?${params}`);
+    if (!response.ok) {
+      throw new Error(`Failed to get history: ${response.status} ${response.statusText}`);
+    }
+    const data = await response.json() as any;
+    return data.snapshots || [];
+  }
+
+  async pullSnapshot(snapshotId: number, cryptoManager: any): Promise<Record<string, any> | null> {
+    const response = await this.request('GET', `/api/machines/snapshot/${snapshotId}`);
+    if (response.status === 404) return null;
+    if (!response.ok) {
+      throw new Error(`Failed to get snapshot: ${response.status} ${response.statusText}`);
+    }
+    const data = await response.json() as any;
+    const encryptedBuffer = Buffer.from(data.encrypted_state, 'base64');
+    const decrypted = cryptoManager.decrypt(encryptedBuffer);
+    return JSON.parse(decrypted.toString());
+  }
+
   async syncEnvironments(
     environments: any[],
     options?: { deleteCloudOnly?: boolean },

--- a/src/lib/concurrency.ts
+++ b/src/lib/concurrency.ts
@@ -1,0 +1,25 @@
+/**
+ * Simple concurrent map utility to limit parallel operations.
+ */
+export async function pMap<T, R>(
+  items: T[],
+  fn: (item: T) => Promise<R>,
+  concurrency: number = 8,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let index = 0;
+
+  async function worker(): Promise<void> {
+    while (index < items.length) {
+      const i = index++;
+      results[i] = await fn(items[i]);
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    () => worker(),
+  );
+  await Promise.all(workers);
+  return results;
+}

--- a/src/lib/dependency-graph.ts
+++ b/src/lib/dependency-graph.ts
@@ -1,0 +1,53 @@
+/**
+ * Dependency graph for restore ordering.
+ * Determines which categories can be restored in parallel vs sequentially.
+ */
+
+const RESTORE_DEPS: Record<string, string[]> = {
+  configs: [],
+  env_files: [],
+  modules: [],
+  packages: [],
+  repos: ['modules'],
+  projects: ['repos'],
+  groups: ['repos'],
+};
+
+/**
+ * Returns execution levels via topological sort.
+ * Items at the same level can run in parallel.
+ * Each level must complete before the next begins.
+ *
+ * Result: [['configs', 'env_files', 'modules', 'packages'], ['repos'], ['projects', 'groups']]
+ */
+export function getRestoreLevels(): string[][] {
+  const resolved = new Set<string>();
+  const levels: string[][] = [];
+  const remaining = new Set(Object.keys(RESTORE_DEPS));
+
+  while (remaining.size > 0) {
+    const level: string[] = [];
+
+    for (const node of remaining) {
+      const deps = RESTORE_DEPS[node] || [];
+      if (deps.every(dep => resolved.has(dep))) {
+        level.push(node);
+      }
+    }
+
+    if (level.length === 0) {
+      // Circular dependency — shouldn't happen, but break to avoid infinite loop
+      level.push(...remaining);
+      remaining.clear();
+    }
+
+    for (const node of level) {
+      remaining.delete(node);
+      resolved.add(node);
+    }
+
+    levels.push(level);
+  }
+
+  return levels;
+}

--- a/src/lib/filter.ts
+++ b/src/lib/filter.ts
@@ -1,0 +1,62 @@
+/**
+ * Filter system for selective push/pull operations.
+ */
+
+export type FilterType = 'configs' | 'repos' | 'env_files' | 'modules' | 'packages' | 'projects' | 'groups';
+
+const VALID_TYPES: Set<string> = new Set(['configs', 'repos', 'env_files', 'modules', 'packages', 'projects', 'groups']);
+
+export interface Filter {
+  type: FilterType;
+  name?: string;
+}
+
+/**
+ * Parse filter strings like "modules:ssh", "configs", "modules:ssh,configs"
+ * Accepts an array of strings (from commander variadic), each potentially comma-separated.
+ */
+export function parseFilters(raw: string[]): Filter[] {
+  const filters: Filter[] = [];
+
+  for (const arg of raw) {
+    for (const part of arg.split(',')) {
+      const trimmed = part.trim();
+      if (!trimmed) continue;
+
+      const colonIdx = trimmed.indexOf(':');
+      if (colonIdx === -1) {
+        if (VALID_TYPES.has(trimmed)) {
+          filters.push({ type: trimmed as FilterType });
+        }
+      } else {
+        const type = trimmed.slice(0, colonIdx);
+        const name = trimmed.slice(colonIdx + 1);
+        if (VALID_TYPES.has(type) && name) {
+          filters.push({ type: type as FilterType, name });
+        }
+      }
+    }
+  }
+
+  return filters;
+}
+
+/**
+ * Check if an item should be included given active filters.
+ * If no filters are set, everything is included.
+ * If filters are set, only matching types (and optionally names) are included.
+ */
+export function shouldInclude(type: FilterType, name: string | undefined, filters: Filter[]): boolean {
+  if (filters.length === 0) return true;
+
+  return filters.some(f => {
+    if (f.type !== type) return false;
+    if (f.name && name) return name.toLowerCase().includes(f.name.toLowerCase());
+    if (f.name && !name) return false;
+    return true;
+  });
+}
+
+export function isFilterActive(filters: Filter[]): boolean {
+  return filters.length > 0;
+}

--- a/src/lib/hash-cache.ts
+++ b/src/lib/hash-cache.ts
@@ -1,0 +1,105 @@
+/**
+ * Content-hash caching for push operations.
+ * Tracks SHA-256 hashes of tracked files to skip re-encrypting unchanged content.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+export interface HashEntry {
+  sha256: string;
+  size: number;
+  mtime: number;
+  encryptedBase64: string;
+}
+
+export interface HashCache {
+  version: 1;
+  lastPush: string;
+  entries: Record<string, HashEntry>;
+}
+
+export class HashCacheManager {
+  private cacheFile: string;
+
+  constructor(stateDir: string) {
+    this.cacheFile = path.join(stateDir, 'hashes.json');
+  }
+
+  load(): HashCache {
+    try {
+      if (fs.existsSync(this.cacheFile)) {
+        const data = JSON.parse(fs.readFileSync(this.cacheFile, 'utf-8'));
+        if (data.version === 1) return data;
+      }
+    } catch {
+      // Corrupted cache, start fresh
+    }
+    return { version: 1, lastPush: '', entries: {} };
+  }
+
+  save(cache: HashCache): void {
+    cache.lastPush = new Date().toISOString();
+    fs.mkdirSync(path.dirname(this.cacheFile), { recursive: true });
+    fs.writeFileSync(this.cacheFile, JSON.stringify(cache));
+  }
+
+  /**
+   * Check if a file has changed since last push.
+   * Fast path: if mtime matches, skip hashing.
+   * Slow path: compute SHA-256 and compare.
+   */
+  check(filePath: string, sourceKey: string, cache: HashCache): { changed: boolean; cachedContent?: string; sha256: string; size: number; mtime: number } {
+    const stat = fs.statSync(filePath);
+    const mtime = stat.mtimeMs;
+    const size = stat.size;
+    const entry = cache.entries[sourceKey];
+
+    // Fast path: mtime and size unchanged
+    if (entry && entry.mtime === mtime && entry.size === size) {
+      return { changed: false, cachedContent: entry.encryptedBase64, sha256: entry.sha256, size, mtime };
+    }
+
+    // Slow path: compute hash
+    const content = fs.readFileSync(filePath);
+    const sha256 = crypto.createHash('sha256').update(content).digest('hex');
+
+    if (entry && entry.sha256 === sha256) {
+      // Content unchanged despite mtime change — update mtime in cache
+      entry.mtime = mtime;
+      entry.size = size;
+      return { changed: false, cachedContent: entry.encryptedBase64, sha256, size, mtime };
+    }
+
+    return { changed: true, sha256, size, mtime };
+  }
+
+  update(cache: HashCache, sourceKey: string, sha256: string, size: number, mtime: number, encryptedBase64: string): void {
+    cache.entries[sourceKey] = { sha256, size, mtime, encryptedBase64 };
+  }
+
+  /**
+   * Remove entries from cache that are no longer tracked.
+   */
+  prune(cache: HashCache, activeKeys: Set<string>): void {
+    for (const key of Object.keys(cache.entries)) {
+      if (!activeKeys.has(key)) {
+        delete cache.entries[key];
+      }
+    }
+  }
+}
+
+/**
+ * Merge current (changed) items with previous (unchanged) items from last push.
+ * Used by --changed flag to build a complete state from partial capture.
+ */
+export function mergeWithPrevious<T extends Record<string, any>>(
+  current: T[],
+  previous: T[],
+  keyField: string,
+): T[] {
+  const currentKeys = new Set(current.map(item => item[keyField]));
+  const fromPrevious = (previous || []).filter(item => !currentKeys.has(item[keyField]));
+  return [...current, ...fromPrevious];
+}

--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -1,8 +1,11 @@
 /**
  * Package manager detection and scanning.
  */
-import { execSync } from 'node:child_process';
+import { execSync, execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import os from 'node:os';
+
+const execFileAsync = promisify(execFile);
 
 export interface PackageManager {
   name: string;
@@ -207,6 +210,34 @@ export function scanPackages(): PackageManager[] {
   }
 
   return results;
+}
+
+/**
+ * Async version of scanPackages — runs all available managers in parallel.
+ */
+export async function scanPackagesAsync(): Promise<PackageManager[]> {
+  const available = managers.filter(m => cmdExists(m.checkCmd));
+
+  const results = await Promise.allSettled(
+    available.map(async (mgr): Promise<PackageManager | null> => {
+      try {
+        const { stdout } = await execFileAsync('sh', ['-c', mgr.listCmd], {
+          timeout: 30000,
+          maxBuffer: 10 * 1024 * 1024,
+        });
+        const packages = mgr.parseOutput(stdout);
+        if (packages.length === 0) return null;
+        return { name: mgr.name, displayName: mgr.displayName, available: true, packages };
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  return results
+    .filter((r): r is PromiseFulfilledResult<PackageManager | null> => r.status === 'fulfilled')
+    .map(r => r.value)
+    .filter((r): r is PackageManager => r !== null);
 }
 
 export function formatPackageSummary(managers: PackageManager[]): string {


### PR DESCRIPTION
## Summary
- **Content-hash caching**: SHA-256 file hashing skips re-encrypting unchanged files, with mtime fast-path and encrypted content cache in `~/.configsync/state/hashes.json`
- **Parallel operations**: Independent capture/restore sections run concurrently via `Promise.all()`, plus async parallel package scanning
- **Dry-run mode**: `--dry-run` flag on pull previews all changes without writing files
- **Filter flag**: `--filter` on push/pull for selective sync (e.g. `modules:ssh,configs`)
- **Changed flag**: `--changed` on push merges only modified items with previous state
- **Dependency graph**: Topological sort ensures correct restore order (modules → repos → projects)
- **Snapshot history**: `configsync history` command lists past snapshots; `--snapshot <id>` on pull restores specific versions
- **Watch mode**: `configsync watch` monitors tracked files with `fs.watch()` and auto-pushes with debounce

## Test plan
- [ ] `configsync push` works as before (backward compatible)
- [ ] `configsync push` second run is faster due to hash caching
- [ ] `configsync push --no-cache` forces re-encryption
- [ ] `configsync push --filter=modules:ssh` only captures SSH module
- [ ] `configsync push --changed` with no changes is near-instant
- [ ] `configsync pull --dry-run` shows preview without writing
- [ ] `configsync pull --filter=configs` only restores configs
- [ ] `configsync pull --snapshot=<id>` restores a specific version
- [ ] `configsync history` lists past snapshots
- [ ] `configsync watch` detects file changes and auto-pushes
- [ ] `npx tsc --noEmit` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)